### PR TITLE
element: allow gstreamer to automatically pick unique element names

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -85,7 +85,12 @@ impl Bin{
     /// Creates a new bin with the given name.
     pub fn new(name: &str) -> Option<Bin>{
         unsafe{
-            let bin = gst_bin_new(to_c_str!(name));
+            let name = if name != "" {
+                to_c_str!(name)
+            } else {
+                ptr::null()
+            };
+            let bin = gst_bin_new(name);
             if bin != ptr::null_mut(){
 	            gst_object_ref_sink(mem::transmute(bin));
 	            Bin::new_from_gst_bin(bin as *mut GstBin)

--- a/src/element.rs
+++ b/src/element.rs
@@ -24,7 +24,12 @@ impl Drop for Element{
 impl Element{
     pub fn new(element_name: &str, name: &str) -> Option<Element>{
         unsafe{
-            let element = gst_element_factory_make(to_c_str!(element_name), to_c_str!(name));
+            let name = if name != "" {
+                to_c_str!(name)
+            } else {
+                ptr::null()
+            };
+            let element = gst_element_factory_make(to_c_str!(element_name), name);
             if element != ptr::null_mut::<GstElement>(){
                 gst_object_ref_sink(mem::transmute(element));
                 Some( Element{element: element} )


### PR DESCRIPTION
could've gone with Option(&str) but that would've broken downwards compatibility.
