### PR TITLE
[Minor] A little more documentation. Also, introducing Element::link_many

### DIFF
--- a/src/appsrc.rs
+++ b/src/appsrc.rs
@@ -22,7 +22,15 @@ impl AppSrc{
     pub fn new_from_element(element: ::Element) -> AppSrc{
         AppSrc{appsrc: element}
     }
-    
+
+    /// Set the capabilities on the `AppSrc`. After calling this method, the source will only
+    /// produce caps that match `caps`. Once caps is set, the caps on the buffers MUST either
+    /// match the caps OR be left unspecified.
+    ///
+    /// Before operating an `AppSrc`, the `caps` property MUST be set to fixed caps describing
+    /// the format of the data that will be pushed with appsrc EXCEPT when pushing buffers with
+    /// unknown caps, in which case no caps should be set. This is typically true of file-like
+    /// sources that push raw byte buffers.
     pub fn set_caps(&mut self, caps: &::Caps){
         unsafe{
             gst_app_src_set_caps(self.gst_appsrc_mut(), caps.gst_caps());

--- a/src/element.rs
+++ b/src/element.rs
@@ -22,22 +22,23 @@ impl Drop for Element{
 	}
 }
 
-impl Element{
-    pub fn new(element_name: &str, name: &str) -> Option<Element>{
-        let cname = CString::new(name).unwrap();
-        let element_cname = CString::new(element_name).unwrap();
+impl Element {
+    /// Use a factory `factory_name` to create an element with name `element_name`.
+    pub fn new(factory_name: &str, element_name: &str) -> Option<Element> {
+        let cname = CString::new(element_name).unwrap();
+        let element_cname = CString::new(factory_name).unwrap();
         unsafe{
-            let name = if name != "" {
+            let element_name = if element_name != "" {
                 cname.as_ptr()
             } else {
                 ptr::null()
             };
-            let element = gst_element_factory_make(element_cname.as_ptr(), name);
-            if element != ptr::null_mut::<GstElement>(){
+            let element = gst_element_factory_make(element_cname.as_ptr(), element_name);
+            if element != ptr::null_mut::<GstElement>() {
                 gst_object_ref_sink(mem::transmute(element));
                 Some( Element{element: element} )
-            }else{
-				println!("Erroro creating {} return {:?}",element_name, element);
+            } else {
+				println!("Error creating {} return {:?}", factory_name, element);
                 None
             }
         }
@@ -55,6 +56,31 @@ impl Element{
 		}
     }
 
+    /// Link several elements in succession.
+    ///
+    /// Calling `Element::link_many(&mut[&mut A, &mut B, &mut C, ...])` will attempt to link
+    /// `A->B`, then `B->C`, ... . In case of error, this function returns immediately, without
+    /// attempting to unlink.
+    ///
+    /// See `ElementT::link` for more details about linking.
+    ///
+    /// Make sure you have added your elements to a bin or pipeline with
+    /// `Bin::add()`` **before** trying to link them.
+    ///
+    /// returns `true` if all elements could be linked, `false` otherwise.
+    pub fn link_many(items: &mut [&mut ElementT]) -> bool {
+        let mut latest : Option<&mut ElementT> = None;
+        for mut item in items {
+            let item : &mut ElementT = *item;
+            if let Some(prev) = latest {
+                if !prev.link(item) {
+                    return false;
+                }
+            }
+            latest = Some(item)
+        }
+        true
+    }
 }
 
 /// http://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/GstElement.html
@@ -77,7 +103,7 @@ pub trait ElementT: ::Transfer{
     /// If multiple links are possible, only one is established.
 	///
 	/// Make sure you have added your elements to a bin or pipeline with
-	/// Bin::add() before trying to link them.
+	/// Bin::add() **before** trying to link them.
 	///
 	/// returns true if the elements could be linked, false otherwise.
     fn link(&mut self, dst: &mut ElementT) -> bool{
@@ -426,9 +452,9 @@ pub trait ElementT: ::Transfer{
     }
 
     fn set<T>(&self, name: &str, value: T)
-    	where Self:Sized{
+        where Self: Sized {
         let cname = CString::new(name).unwrap();
-        unsafe{
+        unsafe {
             g_object_set(self.gst_element() as *mut  c_void, cname.as_ptr(), value, ptr::null::<gchar>());
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,11 @@ use std::ffi::CStr;
 
 #[macro_use] mod util;
 pub mod ffi;
+
+/// Easy way for applications to extract samples from a pipeline.
 pub mod appsink;
+
+/// Easy way for applications to inject buffers into a pipeline.
 pub mod appsrc;
 mod sample;
 mod caps;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -47,7 +47,7 @@ impl Pipeline{
         }
     }
 
-    /// Creates a new pipeline using gst_parse_launch
+    /// Creates a new pipeline based on the command-line syntax
     pub fn new_from_str(string: &str) -> Result<Pipeline>{
         let mut error = ptr::null_mut::<GError>();
         let cstring = CString::new(string).unwrap();


### PR DESCRIPTION
Function `Element::link_many` is a high-level counterpart for `gst_element_link_many`, which proves quite useful for building pipelines.
