### PR TITLE
fix compilation on arm architecture

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ use std::mem;
 use std::ffi::CString;
 use std::str;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 
 #[macro_use] mod util;
 pub mod ffi;
@@ -75,7 +76,7 @@ mod link_windows;
 
 pub fn init(){
     unsafe{
-        gst_init(ptr::null::<i32>() as *mut i32, ptr::null_mut::<i8>() as *mut *mut *mut i8);
+        gst_init(ptr::null::<i32>() as *mut i32, ptr::null_mut::<c_char>() as *mut *mut *mut c_char);
     }
 }
 


### PR DESCRIPTION
gst_init has params `(int *argc, char **argv[])`. char is i8 on x86, but u8 on arm. Use the raw::c_char type which gets translated to the right char type on each architecture.
