### PR TITLE
Prevent leak of watch in Bus::add_watch

### DIFF
--- a/examples/playbin.rs
+++ b/examples/playbin.rs
@@ -28,7 +28,7 @@ fn main(){
             }
             gst::Message::Eos(_) => {
                 println!("eos received quiting");
-                break;
+                bus.remove_watch(); // will close the bus receiver and exit the loop
             }
             _ => {
                 println!("msg of type `{}` from element `{}`", message.type_name(), message.src_name());


### PR DESCRIPTION
The leak will be prevented only when remove_watch is called.

For a custom watch implementation: the benefit is that there is no need to use weak pointer in order to not leak resources used in the watch.

For a message parsing loop using the bus receiver (as done in the playbin example): the loop could be kept idle after eos to handle another play later and be stopped from another thread using remove_watch.